### PR TITLE
Updating index to match current starter app

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,17 +2,10 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <title>Red Hat Insights | Sample App</title>
+        <title>Red Hat Insights | Notifications</title>
         <esi:include src="/@@insights/static/chrome/snippets/head.html"/>
     </head>
     <body>
-        <div class="pf-c-background-image"></div>        
-        <div class="pf-l-page" id="page">
-            <esi:include src="/@@insights/static/chrome/snippets/header.html"/>
-            <esi:include src="/@@insights/static/chrome/snippets/sidebar.html"/>
-            <main role="main" class="pf-l-page__main" id="root">
-                <esi:include src="/@@insights/static/chrome/snippets/footer.html"/>
-            </main>
-        </div>
+        <esi:include src="/@@insights/static/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
Recently, we changed the ESI structure. Your app may look broken when deployed or using the latest version of insights-chrome. This should fix up the issue!

Related: https://github.com/RedHatInsights/insights-frontend-starter-app/pull/55