### PR TITLE
Add EmptyState for no settings results

### DIFF
--- a/src/SmartComponents/NotificationsIndex/NotificationIndex.test.js
+++ b/src/SmartComponents/NotificationsIndex/NotificationIndex.test.js
@@ -40,11 +40,11 @@ describe('NotificationsIndex', () => {
         store
     };
 
-    it('expect to render a Table', () => {
+    it('expect to render an EmptyState by default (with no endpoints)', () => {
         const wrapper = shallow(
-            <NotificationsIndex { ...defaultProps }/>
+            <NotificationsIndex { ...defaultProps } />
         );
-        expect(wrapper.find('Table').length).toBe(1);
+        expect(wrapper.find('EmptyState').length).toBe(1);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
+++ b/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
@@ -67,7 +67,7 @@ export class NotificationsIndex extends Component {
                 <EmptyStateBody>
                     There are no endpoints configured yet.
                 </EmptyStateBody>
-                <Button variant="primary" to={ '/new' } component={ Link }>New endpoint</Button>
+                <Button variant="primary" to={ '/new' } component={ Link } onClick={ this.props.newEndpoint }>New endpoint</Button>
             </EmptyState>
         </Bullseye>;
     }

--- a/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
+++ b/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
@@ -1,4 +1,14 @@
 import React, { Component } from 'react';
+import {
+    Title,
+    Button,
+    Bullseye,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateBody
+} from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { CubesIcon } from '@patternfly/react-icons';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -47,9 +57,34 @@ export class NotificationsIndex extends Component {
         });
     };
 
-    render() {
+    noResults = () => {
+        return <Bullseye>
+            <EmptyState>
+                <p>
+                    <EmptyStateIcon icon={ CubesIcon } />
+                </p>
+                <Title size="lg">No Endpoins found</Title>
+                <EmptyStateBody>
+                    There are no endpoints configured yet.
+                </EmptyStateBody>
+                <Button variant="primary" to={ '/new' } component={ Link }>New endpoint</Button>
+            </EmptyState>
+        </Bullseye>;
+    }
+
+    resultsTable = () => {
         const tableColumns = [ 'Name', 'URL', 'Active', 'Filters', 'Actions' ];
 
+        return <Table aria-label='Notifications list'
+            variant={ TableVariant.medium }
+            rows={ this.filtersInRowsAndCells() }
+            header={ tableColumns }>
+            <TableHeader />
+            <TableBody />
+        </Table>;
+    }
+
+    render() {
         return (
             <NotificationsPage
                 title='Notifications'
@@ -57,13 +92,7 @@ export class NotificationsIndex extends Component {
                 <LoadingState
                     loading={ this.props.loading }
                     placeholder={ <Skeleton size={ SkeletonSize.lg } /> }>
-                    <Table aria-label='Notifications list'
-                        variant={ TableVariant.medium }
-                        rows={ this.filtersInRowsAndCells() }
-                        header={ tableColumns }>
-                        <TableHeader />
-                        <TableBody />
-                    </Table>
+                    { this.props.endpoints.length > 0 ? this.resultsTable() : this.noResults() }
                 </LoadingState>
             </NotificationsPage>
         );

--- a/src/SmartComponents/NotificationsIndex/__snapshots__/NotificationIndex.test.js.snap
+++ b/src/SmartComponents/NotificationsIndex/__snapshots__/NotificationIndex.test.js.snap
@@ -87,6 +87,7 @@ ShallowWrapper {
               isDisabled={false}
               isFocus={false}
               isHover={false}
+              onClick={[MockFunction]}
               to="/new"
               type="button"
               variant="primary"
@@ -141,6 +142,7 @@ ShallowWrapper {
               isDisabled={false}
               isFocus={false}
               isHover={false}
+              onClick={[MockFunction]}
               to="/new"
               type="button"
               variant="primary"
@@ -190,6 +192,7 @@ ShallowWrapper {
               isDisabled={false}
               isFocus={false}
               isHover={false}
+              onClick={[MockFunction]}
               to="/new"
               type="button"
               variant="primary"
@@ -234,6 +237,7 @@ ShallowWrapper {
                 isDisabled={false}
                 isFocus={false}
                 isHover={false}
+                onClick={[MockFunction]}
                 to="/new"
                 type="button"
                 variant="primary"
@@ -310,6 +314,7 @@ ShallowWrapper {
                 "isDisabled": false,
                 "isFocus": false,
                 "isHover": false,
+                "onClick": [MockFunction],
                 "to": "/new",
                 "type": "button",
                 "variant": "primary",
@@ -374,6 +379,7 @@ ShallowWrapper {
                 isDisabled={false}
                 isFocus={false}
                 isHover={false}
+                onClick={[MockFunction]}
                 to="/new"
                 type="button"
                 variant="primary"
@@ -428,6 +434,7 @@ ShallowWrapper {
                 isDisabled={false}
                 isFocus={false}
                 isHover={false}
+                onClick={[MockFunction]}
                 to="/new"
                 type="button"
                 variant="primary"
@@ -477,6 +484,7 @@ ShallowWrapper {
                 isDisabled={false}
                 isFocus={false}
                 isHover={false}
+                onClick={[MockFunction]}
                 to="/new"
                 type="button"
                 variant="primary"
@@ -521,6 +529,7 @@ ShallowWrapper {
                   isDisabled={false}
                   isFocus={false}
                   isHover={false}
+                  onClick={[MockFunction]}
                   to="/new"
                   type="button"
                   variant="primary"
@@ -597,6 +606,7 @@ ShallowWrapper {
                   "isDisabled": false,
                   "isFocus": false,
                   "isHover": false,
+                  "onClick": [MockFunction],
                   "to": "/new",
                   "type": "button",
                   "variant": "primary",

--- a/src/SmartComponents/NotificationsIndex/__snapshots__/NotificationIndex.test.js.snap
+++ b/src/SmartComponents/NotificationsIndex/__snapshots__/NotificationIndex.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NotificationsIndex expect to render a Table 1`] = `
+exports[`NotificationsIndex expect to render an EmptyState by default (with no endpoints) 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <NotificationsIndex
@@ -53,22 +53,48 @@ ShallowWrapper {
           />
         }
       >
-        <Table
-          aria-label="Notifications list"
-          header={
-            Array [
-              "Name",
-              "URL",
-              "Active",
-              "Filters",
-              "Actions",
-            ]
-          }
-          rows={Array []}
+        <Bullseye
+          className=""
+          component="div"
         >
-          <TableHeader />
-          <TableBody />
-        </Table>
+          <EmptyState
+            className=""
+          >
+            <p>
+              <EmptyStateIcon
+                className=""
+                icon={[Function]}
+              />
+            </p>
+            <Title
+              className=""
+              headingLevel="h1"
+              size="lg"
+            >
+              No Endpoins found
+            </Title>
+            <EmptyStateBody
+              className=""
+            >
+              There are no endpoints configured yet.
+            </EmptyStateBody>
+            <Button
+              aria-label={null}
+              className=""
+              component={[Function]}
+              isActive={false}
+              isBlock={false}
+              isDisabled={false}
+              isFocus={false}
+              isHover={false}
+              to="/new"
+              type="button"
+              variant="primary"
+            >
+              New endpoint
+            </Button>
+          </EmptyState>
+        </Bullseye>
       </LoadingState>,
       "rightBar": <IndexToolbar
         onClick={[MockFunction]}
@@ -81,22 +107,48 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
-        "children": <Table
-          aria-label="Notifications list"
-          header={
-            Array [
-              "Name",
-              "URL",
-              "Active",
-              "Filters",
-              "Actions",
-            ]
-          }
-          rows={Array []}
+        "children": <Bullseye
+          className=""
+          component="div"
         >
-          <TableHeader />
-          <TableBody />
-        </Table>,
+          <EmptyState
+            className=""
+          >
+            <p>
+              <EmptyStateIcon
+                className=""
+                icon={[Function]}
+              />
+            </p>
+            <Title
+              className=""
+              headingLevel="h1"
+              size="lg"
+            >
+              No Endpoins found
+            </Title>
+            <EmptyStateBody
+              className=""
+            >
+              There are no endpoints configured yet.
+            </EmptyStateBody>
+            <Button
+              aria-label={null}
+              className=""
+              component={[Function]}
+              isActive={false}
+              isBlock={false}
+              isDisabled={false}
+              isFocus={false}
+              isHover={false}
+              to="/new"
+              type="button"
+              variant="primary"
+            >
+              New endpoint
+            </Button>
+          </EmptyState>
+        </Bullseye>,
         "loading": undefined,
         "placeholder": <Skeleton
           size="lg"
@@ -108,42 +160,167 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "function",
         "props": Object {
-          "aria-label": "Notifications list",
-          "children": Array [
-            <TableHeader />,
-            <TableBody />,
-          ],
-          "header": Array [
-            "Name",
-            "URL",
-            "Active",
-            "Filters",
-            "Actions",
-          ],
-          "rows": Array [],
-          "variant": undefined,
+          "children": <EmptyState
+            className=""
+          >
+            <p>
+              <EmptyStateIcon
+                className=""
+                icon={[Function]}
+              />
+            </p>
+            <Title
+              className=""
+              headingLevel="h1"
+              size="lg"
+            >
+              No Endpoins found
+            </Title>
+            <EmptyStateBody
+              className=""
+            >
+              There are no endpoints configured yet.
+            </EmptyStateBody>
+            <Button
+              aria-label={null}
+              className=""
+              component={[Function]}
+              isActive={false}
+              isBlock={false}
+              isDisabled={false}
+              isFocus={false}
+              isHover={false}
+              to="/new"
+              type="button"
+              variant="primary"
+            >
+              New endpoint
+            </Button>
+          </EmptyState>,
+          "className": "",
+          "component": "div",
         },
         "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {},
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": Array [
+              <p>
+                <EmptyStateIcon
+                  className=""
+                  icon={[Function]}
+                />
+              </p>,
+              <Title
+                className=""
+                headingLevel="h1"
+                size="lg"
+              >
+                No Endpoins found
+              </Title>,
+              <EmptyStateBody
+                className=""
+              >
+                There are no endpoints configured yet.
+              </EmptyStateBody>,
+              <Button
+                aria-label={null}
+                className=""
+                component={[Function]}
+                isActive={false}
+                isBlock={false}
+                isDisabled={false}
+                isFocus={false}
+                isHover={false}
+                to="/new"
+                type="button"
+                variant="primary"
+              >
+                New endpoint
+              </Button>,
+            ],
+            "className": "",
           },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {},
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-        ],
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <EmptyStateIcon
+                  className=""
+                  icon={[Function]}
+                />,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "className": "",
+                  "icon": [Function],
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "p",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": "No Endpoins found",
+                "className": "",
+                "headingLevel": "h1",
+                "size": "lg",
+              },
+              "ref": null,
+              "rendered": "No Endpoins found",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "children": "There are no endpoints configured yet.",
+                "className": "",
+              },
+              "ref": null,
+              "rendered": "There are no endpoints configured yet.",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "aria-label": null,
+                "children": "New endpoint",
+                "className": "",
+                "component": [Function],
+                "isActive": false,
+                "isBlock": false,
+                "isDisabled": false,
+                "isFocus": false,
+                "isHover": false,
+                "to": "/new",
+                "type": "button",
+                "variant": "primary",
+              },
+              "ref": null,
+              "rendered": "New endpoint",
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
         "type": [Function],
       },
       "type": [Function],
@@ -163,22 +340,48 @@ ShallowWrapper {
             />
           }
         >
-          <Table
-            aria-label="Notifications list"
-            header={
-              Array [
-                "Name",
-                "URL",
-                "Active",
-                "Filters",
-                "Actions",
-              ]
-            }
-            rows={Array []}
+          <Bullseye
+            className=""
+            component="div"
           >
-            <TableHeader />
-            <TableBody />
-          </Table>
+            <EmptyState
+              className=""
+            >
+              <p>
+                <EmptyStateIcon
+                  className=""
+                  icon={[Function]}
+                />
+              </p>
+              <Title
+                className=""
+                headingLevel="h1"
+                size="lg"
+              >
+                No Endpoins found
+              </Title>
+              <EmptyStateBody
+                className=""
+              >
+                There are no endpoints configured yet.
+              </EmptyStateBody>
+              <Button
+                aria-label={null}
+                className=""
+                component={[Function]}
+                isActive={false}
+                isBlock={false}
+                isDisabled={false}
+                isFocus={false}
+                isHover={false}
+                to="/new"
+                type="button"
+                variant="primary"
+              >
+                New endpoint
+              </Button>
+            </EmptyState>
+          </Bullseye>
         </LoadingState>,
         "rightBar": <IndexToolbar
           onClick={[MockFunction]}
@@ -191,22 +394,48 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "function",
         "props": Object {
-          "children": <Table
-            aria-label="Notifications list"
-            header={
-              Array [
-                "Name",
-                "URL",
-                "Active",
-                "Filters",
-                "Actions",
-              ]
-            }
-            rows={Array []}
+          "children": <Bullseye
+            className=""
+            component="div"
           >
-            <TableHeader />
-            <TableBody />
-          </Table>,
+            <EmptyState
+              className=""
+            >
+              <p>
+                <EmptyStateIcon
+                  className=""
+                  icon={[Function]}
+                />
+              </p>
+              <Title
+                className=""
+                headingLevel="h1"
+                size="lg"
+              >
+                No Endpoins found
+              </Title>
+              <EmptyStateBody
+                className=""
+              >
+                There are no endpoints configured yet.
+              </EmptyStateBody>
+              <Button
+                aria-label={null}
+                className=""
+                component={[Function]}
+                isActive={false}
+                isBlock={false}
+                isDisabled={false}
+                isFocus={false}
+                isHover={false}
+                to="/new"
+                type="button"
+                variant="primary"
+              >
+                New endpoint
+              </Button>
+            </EmptyState>
+          </Bullseye>,
           "loading": undefined,
           "placeholder": <Skeleton
             size="lg"
@@ -218,42 +447,167 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "function",
           "props": Object {
-            "aria-label": "Notifications list",
-            "children": Array [
-              <TableHeader />,
-              <TableBody />,
-            ],
-            "header": Array [
-              "Name",
-              "URL",
-              "Active",
-              "Filters",
-              "Actions",
-            ],
-            "rows": Array [],
-            "variant": undefined,
+            "children": <EmptyState
+              className=""
+            >
+              <p>
+                <EmptyStateIcon
+                  className=""
+                  icon={[Function]}
+                />
+              </p>
+              <Title
+                className=""
+                headingLevel="h1"
+                size="lg"
+              >
+                No Endpoins found
+              </Title>
+              <EmptyStateBody
+                className=""
+              >
+                There are no endpoints configured yet.
+              </EmptyStateBody>
+              <Button
+                aria-label={null}
+                className=""
+                component={[Function]}
+                isActive={false}
+                isBlock={false}
+                isDisabled={false}
+                isFocus={false}
+                isHover={false}
+                to="/new"
+                type="button"
+                variant="primary"
+              >
+                New endpoint
+              </Button>
+            </EmptyState>,
+            "className": "",
+            "component": "div",
           },
           "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {},
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <p>
+                  <EmptyStateIcon
+                    className=""
+                    icon={[Function]}
+                  />
+                </p>,
+                <Title
+                  className=""
+                  headingLevel="h1"
+                  size="lg"
+                >
+                  No Endpoins found
+                </Title>,
+                <EmptyStateBody
+                  className=""
+                >
+                  There are no endpoints configured yet.
+                </EmptyStateBody>,
+                <Button
+                  aria-label={null}
+                  className=""
+                  component={[Function]}
+                  isActive={false}
+                  isBlock={false}
+                  isDisabled={false}
+                  isFocus={false}
+                  isHover={false}
+                  to="/new"
+                  type="button"
+                  variant="primary"
+                >
+                  New endpoint
+                </Button>,
+              ],
+              "className": "",
             },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {},
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-          ],
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <EmptyStateIcon
+                    className=""
+                    icon={[Function]}
+                  />,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "className": "",
+                    "icon": [Function],
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": "p",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "No Endpoins found",
+                  "className": "",
+                  "headingLevel": "h1",
+                  "size": "lg",
+                },
+                "ref": null,
+                "rendered": "No Endpoins found",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "children": "There are no endpoints configured yet.",
+                  "className": "",
+                },
+                "ref": null,
+                "rendered": "There are no endpoints configured yet.",
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "aria-label": null,
+                  "children": "New endpoint",
+                  "className": "",
+                  "component": [Function],
+                  "isActive": false,
+                  "isBlock": false,
+                  "isDisabled": false,
+                  "isFocus": false,
+                  "isHover": false,
+                  "to": "/new",
+                  "type": "button",
+                  "variant": "primary",
+                },
+                "ref": null,
+                "rendered": "New endpoint",
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
           "type": [Function],
         },
         "type": [Function],


### PR DESCRIPTION
This adds the EmptyState for when no endpoint configuration settins are returned by the API and looks like this now:

![screen shot 2019-03-07 at 12 11 31](https://user-images.githubusercontent.com/7757/53952866-48312180-40d2-11e9-86fa-cad1beb134b4.png)
