### PR TITLE
Updates for new chrome and proxy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,7 @@ There is also a docker-compose file to start the insights-proxy with a local ins
  3. Change the `LOCAL_CHROME_PATH` environment path to point to the locally built insights-chrome
  4. [Update your hosts file](https://github.com/RedHatInsights/insights-proxy#setup-the-initial-etchosts-entries-do-this-once) to have required development host names correctly resolved
  5. Run `docker-compose up` in the notifications-frontend directory
- 6. If all built correctly the frontend should be available at https://ci.foo.redhat.com:1337/apps/webhooks/
-
-_* At this time the insights-chrome need to have an new entry to find the webhooks frontend, which needs to be added to `src/js/nav/globalNav.js` in the local chrome as follows:_
-
-```
-{
-    id: 'webhooks',
-    title: 'Webhooks'
-}
-```
-
-This also requires to rebuilt the chrome via `npm run build`
+ 6. If all built correctly the frontend should be available at https://ci.foo.redhat.com:1337/insights/webhooks/
 
 ## Code preferences
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ There is also a docker-compose file to start the insights-proxy with a local ins
  3. Change the `LOCAL_CHROME_PATH` environment path to point to the locally built insights-chrome
  4. [Update your hosts file](https://github.com/RedHatInsights/insights-proxy#setup-the-initial-etchosts-entries-do-this-once) to have required development host names correctly resolved
  5. Run `docker-compose up` in the notifications-frontend directory
- 6. If all built correctly the frontend should be available at https://prod.foo.redhat.com:1337/insights/platform/notifications/
+ 6. If all built correctly the frontend should be available at https://ci.foo.redhat.com:1337/apps/webhooks/
 
-_* At this time the insights-chrome need to have an new entry to find the notifications frontend, which needs to be added to `src/js/nav/globalNav.js` as follows:_
+_* At this time the insights-chrome need to have an new entry to find the webhooks frontend, which needs to be added to `src/js/nav/globalNav.js` in the local chrome as follows:_
 
 ```
 {
-    id: 'notifications',
-    title: 'Notifications'
+    id: 'webhooks',
+    title: 'Webhooks'
 }
 ```
+
+This also requires to rebuilt the chrome via `npm run build`
 
 ## Code preferences
 

--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -88,8 +88,8 @@ plugins.push(CopyFilesWebpackPlugin);
  * This handles the path being either insights or insightsbeta in the esi:include.
  */
 const HtmlReplaceWebpackPlugin = new(require('html-replace-webpack-plugin'))([{
-    pattern: '@@insights',
-    replacement: config.insightsDeployment
+    pattern: '@@env',
+    replacement: config.deploymentEnv
 }]);
 plugins.push(HtmlReplaceWebpackPlugin);
 

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,0 +1,10 @@
+/*global module, process*/
+
+const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
+
+module.exports = {
+    routes: {
+        '/apps/notifications': { host: `http://${localhost}:8002` },
+        '/api/notifications': { host: `http://${localhost}:3000` }
+    }
+};

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -4,7 +4,8 @@ const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docke
 
 module.exports = {
     routes: {
-        '/apps/notifications': { host: `http://${localhost}:8002` },
-        '/api/notifications': { host: `http://${localhost}:3000` }
+        '/apps/webhooks': { host: `http://${localhost}:8002` },
+        '/insights/webhooks': { host: `http://${localhost}:8002` },
+        '/api/webhooks': { host: `http://${localhost}:3000` }
     }
 };

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV === 'production' && betaBranch) {
     deploymentEnv = 'beta/apps';
 }
 
-const publicPath = `/${deploymentEnv}/notifications/`;
+const publicPath = `/${deploymentEnv}/webhooks/`;
 
 module.exports = {
     paths: {

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -1,4 +1,4 @@
-/* global require, module, __dirname */
+/* global require, module, __dirname, process */
 
 const path = require('path');
 const GitRevisionPlugin = require('git-revision-webpack-plugin');
@@ -9,17 +9,17 @@ const entry = process.env.NODE_ENV === 'production' ?
     path.resolve(__dirname, '../src/entry.js') :
     path.resolve(__dirname, '../src/entry-dev.js');
 
-let insightsDeployment = 'insights';
+let deploymentEnv = 'apps';
 const gitBranch = process.env.BRANCH || gitRevisionPlugin.branch();
 const betaBranch =
     gitBranch === 'master' ||
     gitBranch === 'qa-beta' ||
     gitBranch === 'prod-beta';
 if (process.env.NODE_ENV === 'production' && betaBranch) {
-    insightsDeployment = 'insightsbeta';
+    deploymentEnv = 'beta/apps';
 }
 
-const publicPath = `/${insightsDeployment}/platform/notifications/`;
+const publicPath = `/${deploymentEnv}/notifications/`;
 
 module.exports = {
     paths: {
@@ -32,5 +32,5 @@ module.exports = {
         static: path.resolve(__dirname, '../static'),
         publicPath
     },
-    insightsDeployment
+    deploymentEnv
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,6 @@ services:
       - LOCAL_API=true
       - LOCAL_API_SCHEME=http
       - LOCAL_API_PORT=3000
+    volumes:
+      - ${LOCAL_CHROME_PATH}:/chrome:Z
+      - ./config/spandx.config.js:/config/spandx.config.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,3 @@ services:
       - LOCAL_API=true
       - LOCAL_API_SCHEME=http
       - LOCAL_API_PORT=3000
-    volumes:
-      - ${LOCAL_CHROME_PATH}:/chrome:Z

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "verify": "npm-run-all build lint test"
   },
   "insights": {
-    "appname": "notifications"
+    "appname": "webhooks"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ class App extends Component {
 
     componentDidMount() {
         insights.chrome.init();
-        insights.chrome.identifyApp('notifications');
+        insights.chrome.identifyApp('webhooks');
         insights.chrome.navigation(buildNavigation());
 
         this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));

--- a/src/Utilities/notificationsBackendAPI.js
+++ b/src/Utilities/notificationsBackendAPI.js
@@ -1,4 +1,4 @@
-export const NOTIFICATIONS_API_ROOT = '/r/insights/platform/notifications';
+export const NOTIFICATIONS_API_ROOT = '/api/webhooks';
 
 export const API_HEADERS = {
     'Content-Type': 'application/json',

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -8,13 +8,14 @@ import App from './App';
 const pathName = window.location.pathname.split('/');
 pathName.shift();
 
+let release = '/';
 if (pathName[0] === 'beta') {
-    pathName.shift();
+    release = `/${pathName.shift()}/`;
 }
 
 ReactDOM.render(
     <Provider store={ init().getStore() }>
-        <Router basename={ `${pathName[0]}/${pathName[1]}` }>
+        <Router basename={ `${release}${pathName[0]}/${pathName[1]}` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -2,22 +2,20 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { init } from 'Store';
+import { init } from './store';
 import App from './App';
-import logger from 'redux-logger';
 
-// exposes webpack variable RELEASE
-/*global RELEASE:true*/
-/*eslint no-undef: "error"*/
+const pathName = window.location.pathname.split('/');
+pathName.shift();
 
-/**
- * Hooks up redux to app.
- *  https://redux.js.org/advanced/usage-with-react-router
- */
+if (pathName[0] === 'beta') {
+    pathName.shift();
+}
+
 ReactDOM.render(
-    <Provider store={ init(logger).getStore() }>
-        <Router basename={ `/${RELEASE}/platform/notifications` }>
-            <App/>
+    <Provider store={ init().getStore() }>
+        <Router basename={ `${pathName[0]}/${pathName[1]}` }>
+            <App />
         </Router>
     </Provider>,
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -2,22 +2,22 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { init } from 'Store';
+import { init } from './store';
 import App from './App';
 
-// exposes webpack variable RELEASE
-/*global RELEASE:true*/
-/*eslint no-undef: "error"*/
+const pathName = window.location.pathname.split('/');
+pathName.shift();
 
-/**
- * Hooks up redux to app.
- *  https://redux.js.org/advanced/usage-with-react-router
- */
+if (pathName[0] === 'beta') {
+    pathName.shift();
+}
+
 ReactDOM.render(
     <Provider store={ init().getStore() }>
-        <Router basename={ `/${RELEASE}/platform/notifications` }>
+        <Router basename={ `${pathName[0]}/${pathName[1]}` }>
             <App />
         </Router>
     </Provider>,
+
     document.getElementById('root')
 );

--- a/src/entry.js
+++ b/src/entry.js
@@ -8,13 +8,14 @@ import App from './App';
 const pathName = window.location.pathname.split('/');
 pathName.shift();
 
+let release = '/';
 if (pathName[0] === 'beta') {
-    pathName.shift();
+    release = `/${pathName.shift()}/`;
 }
 
 ReactDOM.render(
     <Provider store={ init().getStore() }>
-        <Router basename={ `${pathName[0]}/${pathName[1]}` }>
+        <Router basename={ `${release}${pathName[0]}/${pathName[1]}` }>
             <App />
         </Router>
     </Provider>,

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,10 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <title>Red Hat Insights | Notifications</title>
-        <esi:include src="/@@insights/static/chrome/snippets/head.html"/>
+        <title>Red Hat Cloud Software Services</title>
+        <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>
-        <esi:include src="/@@insights/static/chrome/snippets/body.html"/>
+        <esi:include src="/@@env/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
This updates the UI app to current changes for the proxy and chrome.
For the backend the following PR in the backend will also be required to match the new URl schema for APIs: https://github.com/RedHatInsights/notifications-backend/pull/36

We still need to add ourselves to the navigation for it to work and be identified correctly. This changed from 'nortifications' to 'webhooks'. Once https://github.com/RedHatInsights/insights-chrome/pull/200 is merged we won't need to do this and can update the readme and docker compose setup to simply use the proxy image.

The readme is also updated to reflect the correct URL to be used during development.


