### PR TITLE
Show validation errors from the server properly is form errors

### DIFF
--- a/src/PresentationalComponents/CustomInputFieldTemplate/CustomInputFieldTemplate.js
+++ b/src/PresentationalComponents/CustomInputFieldTemplate/CustomInputFieldTemplate.js
@@ -8,10 +8,6 @@ export class CustomInputFieldTemplate extends React.Component {
         this.state = { value: props.formData ? props.formData : '' };
     }
 
-    state = {
-        value: ''
-    };
-
     handleTextInputChange = value => {
         this.props.onChange(value);
         this.setState({ value });
@@ -20,12 +16,16 @@ export class CustomInputFieldTemplate extends React.Component {
     render() {
         const { value } = this.state;
         const placeholder = this.props.uiSchema['ui:placeholder'];
+        const hasErrors = this.props.errorSchema.errors;
+        const invalidHelperText = hasErrors ? this.props.errorSchema.errors.join(', ') : '';
 
         return <FormGroup
             label={ this.props.schema.title }
             isRequired={ this.props.required }
+            isValid={ !hasErrors }
+            helperTextInvalid={ invalidHelperText }
             fieldId={ `custom-input-${ this.props.name }` }>
-            <TextInput value={ value } aria-label={ this.props.schema.title }
+            <TextInput value={ value } aria-label={ this.props.schema.title } isValid={ !hasErrors }
                 type="text" onChange={ this.handleTextInputChange } placeholder={ placeholder } />
         </FormGroup>;
     }
@@ -36,6 +36,7 @@ CustomInputFieldTemplate.propTypes = {
     onChange: PropTypes.func,
     schema: PropTypes.object,
     uiSchema: PropTypes.object,
+    errorSchema: PropTypes.object,
     name: PropTypes.string,
     required: PropTypes.bool
 };

--- a/src/PresentationalComponents/CustomInputFieldTemplate/CustomInputFieldTemplate.test.js
+++ b/src/PresentationalComponents/CustomInputFieldTemplate/CustomInputFieldTemplate.test.js
@@ -11,6 +11,7 @@ describe('CustomInputFieldTemplate', () => {
         uiSchema: {
             'ui:placeholder': 'Placeholder text'
         },
+        errorSchema: {},
         onChange: jest.fn(),
         name: 'test-input-field',
         required: true

--- a/src/PresentationalComponents/CustomInputFieldTemplate/__snapshots__/CustomInputFieldTemplate.test.js.snap
+++ b/src/PresentationalComponents/CustomInputFieldTemplate/__snapshots__/CustomInputFieldTemplate.test.js.snap
@@ -4,6 +4,7 @@ exports[`CustomInputFieldTemplate expect to call onChange handler 1`] = `
 <FormGroup
   className=""
   fieldId="custom-input-test-input-field"
+  helperTextInvalid=""
   isInline={false}
   isRequired={true}
   isValid={true}
@@ -28,6 +29,7 @@ exports[`CustomInputFieldTemplate expect to render 1`] = `
 <FormGroup
   className=""
   fieldId="custom-input-test-input-field"
+  helperTextInvalid=""
   isInline={false}
   isRequired={true}
   isValid={true}

--- a/src/SmartComponents/NotificationEdit/__snapshots__/NotificationEdit.test.js.snap
+++ b/src/SmartComponents/NotificationEdit/__snapshots__/NotificationEdit.test.js.snap
@@ -26,7 +26,7 @@ exports[`NotificationEdit expect to render a Form 1`] = `
       formData={Object {}}
       liveValidate={false}
       noHtml5Validate={false}
-      noValidate={false}
+      noValidate={true}
       onSubmit={[Function]}
       safeRenderCompletion={false}
       schema={
@@ -54,6 +54,7 @@ exports[`NotificationEdit expect to render a Form 1`] = `
           "type": "object",
         }
       }
+      showErrorList={false}
       uiSchema={
         Object {
           "name": Object {
@@ -1294,7 +1295,7 @@ exports[`NotificationEdit takes an endpoint 1`] = `
       formData={Object {}}
       liveValidate={false}
       noHtml5Validate={false}
-      noValidate={false}
+      noValidate={true}
       onSubmit={[Function]}
       safeRenderCompletion={false}
       schema={
@@ -1322,6 +1323,7 @@ exports[`NotificationEdit takes an endpoint 1`] = `
           "type": "object",
         }
       }
+      showErrorList={false}
       uiSchema={
         Object {
           "name": Object {

--- a/src/Utilities/notificationsBackendAPI.js
+++ b/src/Utilities/notificationsBackendAPI.js
@@ -15,8 +15,14 @@ class BackendAPIClient {
                 body: JSON.stringify(apiProps)
             });
         }).then((response) => {
-            if (!response.ok) {
+            if (!response.ok && response.status !== 422) {
                 throw new Error(response.statusText);
+            }
+
+            if (response.status === 422) {
+                return response.clone()
+                .json()
+                .then((json) => Promise.reject(json));
             }
 
             return (response.status !== 204) ? response.json() : {};

--- a/src/store/reducers/EndpointsReducer.js
+++ b/src/store/reducers/EndpointsReducer.js
@@ -114,6 +114,7 @@ export const endpointsReducer = function(state = initialStateFor('endpoints', {}
                 ...state,
                 submitting: false,
                 endpoint: action.meta.data,
+                errors: action.payload,
                 error: action.payload.message
             };
 

--- a/src/store/reducers/EndpointsReducer.test.js
+++ b/src/store/reducers/EndpointsReducer.test.js
@@ -172,7 +172,10 @@ describe('endpoint reducer', () => {
             loading: false,
             submitting: false,
             endpoint: {},
-            error
+            error,
+            errors: {
+                message: error
+            }
         });
     });
 


### PR DESCRIPTION
Validation errors coming from the backend are nicely shown as nice form errors:

![Screen Shot 2019-04-17 at 15 47 31](https://user-images.githubusercontent.com/7757/56293107-c567a180-6128-11e9-877d-5a03e48acb02.png)

_(Note: Imagine the background white.)_