### PR TITLE
Expect the backend may 404 when filter does not exist

### DIFF
--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -147,7 +147,14 @@ export const testEndpoint = (endpointId) => ({
 
 export const fetchFilter = (endpointId) => ({
     type: FETCH_FILTER,
-    payload: ApiClient.get(`/endpoints/${ endpointId }/filter`),
+    payload: ApiClient.get(`/endpoints/${ endpointId }/filter`)
+    .catch((error) => {
+        if (error.message === 'Not Found') {
+            return { data: null };
+        } else {
+            throw error;
+        }
+    }),
     meta: {
         notifications: {
             rejected: {

--- a/src/store/reducers/FilterReducer.js
+++ b/src/store/reducers/FilterReducer.js
@@ -9,8 +9,10 @@ import {
     normalizeData
 } from './reducerHelper';
 
-export const normalizeFilterData = (payload) =>
-    normalizeData(payload, 'filter')[payload.data.id];
+export const normalizeFilterData = (payload) => {
+    return payload.data === null ? {}
+        : normalizeData(payload, 'filter')[payload.data.id];
+};
 
 export const filterReducer = function(state = initialStateFor('filter', {}), action) {
     switch (action.type) {
@@ -34,7 +36,7 @@ export const filterReducer = function(state = initialStateFor('filter', {}), act
             return {
                 ...state,
                 loading: false,
-                error: action.payload.error,
+                error: action.payload.errors,
                 filter: {}
             };
 

--- a/src/store/reducers/FilterReducer.test.js
+++ b/src/store/reducers/FilterReducer.test.js
@@ -1,4 +1,6 @@
 import { filterReducer } from './FilterReducer';
+import { successMessage } from './reducerHelper';
+import { FETCH_FILTER } from 'Store/actions/index';
 
 const initialState = {
     error: null,
@@ -10,7 +12,14 @@ describe('filter reducer', () => {
         ...initialState,
         filter: {}
     };
+
     it('should return the initial state', () => {
         expect(filterReducer(undefined, {})).toEqual(filterInitialState);
+    });
+
+    it('should handle payload with null data', () => {
+        const message = { type: successMessage(FETCH_FILTER), payload: { data: null }};
+        const newState = filterReducer(filterInitialState, message);
+        expect(newState).toEqual({ ...filterInitialState, loading: false, error: null, filter: {}});
     });
 });


### PR DESCRIPTION
When https://github.com/RedHatInsights/notifications-backend/pull/48 get in, the backend will start returning 404s when endpoint's filter does not exist. In that case we can safely ignore it and use a default value