### PR TITLE
Handle deletion better

### DIFF
--- a/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
+++ b/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
@@ -158,7 +158,7 @@ export class NotificationsIndex extends Component {
             event.preventDefault();
             this.props.deleteEndpoint(id, name).then(() => {
                 this.filtersInRowsAndCells();
-                this.getNextEndpoint();
+                return this.getNextEndpoint();
             }).then(() => {
                 this.filtersInRowsAndCells();
             });

--- a/src/store/reducers/EndpointsReducer.js
+++ b/src/store/reducers/EndpointsReducer.js
@@ -54,7 +54,7 @@ const deleteEndpointInCollectionObject = (object, id) => {
 
 const handleFetchEndpointsSuccess = (state, action) => {
     if (action.payload.data.length === 0) {
-        return { ...state };
+        return { ...state, loading: false };
     }
 
     let normalizedData = normalizeEndpointData(action.payload, action.meta.endpoint, action.meta.sortBy);

--- a/src/store/reducers/EndpointsReducer.js
+++ b/src/store/reducers/EndpointsReducer.js
@@ -53,6 +53,10 @@ const deleteEndpointInCollectionObject = (object, id) => {
 };
 
 const handleFetchEndpointsSuccess = (state, action) => {
+    if (action.payload.data.length === 0) {
+        return { ...state };
+    }
+
     let normalizedData = normalizeEndpointData(action.payload, action.meta.endpoint, action.meta.sortBy);
     if (action.meta.partial) {
         const data = Object.values(normalizedData)[0];


### PR DESCRIPTION
When we delete an endpoint from the index we try to load next endpoint to show. The code didn't take into consideration that there may not be more records.