### PR TITLE
Refactor API error handling

### DIFF
--- a/src/SmartComponents/NotificationEdit/NotificationEdit.js
+++ b/src/SmartComponents/NotificationEdit/NotificationEdit.js
@@ -75,7 +75,7 @@ export class NotificationEdit extends Component {
         loading: PropTypes.bool,
         filterLoading: PropTypes.bool,
         appsLoading: PropTypes.bool,
-        endpointErrors: PropTypes.object,
+        endpointErrors: PropTypes.array,
         submitting: PropTypes.bool
     }
 
@@ -155,7 +155,14 @@ export class NotificationEdit extends Component {
         ((endpoint) ? this.props.updateEndpoint(endpoint.id, payload) : this.props.createEndpoint(payload))
         .then(this.toIndex)
         .catch(() => {
-            const errors = _.mapValues(this.props.endpointErrors.errors, (value) => ({ errors: value }));
+            let errors = {};
+            _.forEach(this.props.endpointErrors, (value) => {
+                const pointer = value.source.pointer.split('/');
+                const key = pointer[pointer.length - 1];
+                errors[key] = {
+                    errors: [ value.detail ]
+                };
+            });
             this.form.current.setState({
                 errors,
                 errorSchema: errors

--- a/src/Utilities/notificationsBackendAPI.js
+++ b/src/Utilities/notificationsBackendAPI.js
@@ -36,10 +36,18 @@ class BackendAPIClient {
             return { json: () => ({}) };
         }
 
+        const responseCloneJson = response.clone().json();
+
+        if (response.status === 422) {
+            return responseCloneJson.then((json) =>
+                Promise.reject({ ...json, title: 'Validation error' })
+            );
+        }
+
         if (response.status >= 400 && response.status <= 600) {
-            return response.clone()
-            .json()
-            .then((json) => Promise.reject(response.status !== 422 ? json.errors[0] : json));
+            return responseCloneJson.then((json) =>
+                Promise.reject(json.errors[0])
+            );
         }
 
         return response;

--- a/src/Utilities/notificationsBackendAPI.js
+++ b/src/Utilities/notificationsBackendAPI.js
@@ -36,7 +36,7 @@ class BackendAPIClient {
             return { json: () => ({}) };
         }
 
-        const responseCloneJson = response.clone().json();
+        const responseCloneJson = response.clone ? response.clone().json() : response;
 
         if (response.status === 422) {
             return responseCloneJson.then((json) =>

--- a/src/Utilities/notificationsBackendAPI.test.js
+++ b/src/Utilities/notificationsBackendAPI.test.js
@@ -28,6 +28,49 @@ describe('request', () => {
     });
 });
 
+describe('checkForErrors', () => {
+    const errors = {
+        errors: [
+            {
+                title: 'Not found',
+                detail: 'Record not found'
+            }
+        ]
+    };
+
+    it('returns the response if status is not between 400 and <600', () => {
+        const response = {
+            status: 200,
+            body: 'OK'
+        };
+        expect(ApiClient.checkForErrors(response)).toBe(response);
+    });
+
+    it('rejects with first error if status is between 400 and <600', () => {
+        const response = {
+            status: 404,
+            body: 'Not found',
+            json: jest.fn(() => Promise.resolve(errors))
+        };
+        response.clone = jest.fn(() => response);
+
+        expect(ApiClient.checkForErrors(response)).rejects.toBe(errors.errors[0]);
+        expect(response.json).toHaveBeenCalled();
+    });
+
+    it('rejects with the all errors if status is 422', () => {
+        const response = {
+            status: 422,
+            body: 'Unprocessable entity',
+            json: jest.fn(() => Promise.resolve(errors))
+        };
+        response.clone = jest.fn(() => response);
+
+        expect(ApiClient.checkForErrors(response)).rejects.toBe(errors);
+        expect(response.json).toHaveBeenCalled();
+    });
+});
+
 describe('API calls', () => {
     const mockGet = jest.fn(() => ({}));
 

--- a/src/Utilities/notificationsBackendAPI.test.js
+++ b/src/Utilities/notificationsBackendAPI.test.js
@@ -41,8 +41,10 @@ describe('checkForErrors', () => {
     it('returns the response if status is not between 400 and <600', () => {
         const response = {
             status: 200,
-            body: 'OK'
+            body: 'OK',
+            json: jest.fn(() => Promise.resolve(errors))
         };
+        response.clone = jest.fn(() => response);
         expect(ApiClient.checkForErrors(response)).toBe(response);
     });
 

--- a/src/Utilities/notificationsBackendAPI.test.js
+++ b/src/Utilities/notificationsBackendAPI.test.js
@@ -90,7 +90,12 @@ describe('API calls', () => {
     describe('get', () => {
         it('calls request with path and get', () => {
             expect(ApiClient.get('/get')).toEqual({});
-            expect(ApiClient.request).toHaveBeenCalledWith('/get');
+            expect(ApiClient.request).toHaveBeenCalledWith('/get', null, 'get', {});
+        });
+
+        it('passes on options', () => {
+            expect(ApiClient.get('/get', { ignore404: true })).toEqual({});
+            expect(ApiClient.request).toHaveBeenCalledWith('/get', null, 'get', { ignore404: true });
         });
     });
 

--- a/src/store/actions/__snapshots__/index.test.js.snap
+++ b/src/store/actions/__snapshots__/index.test.js.snap
@@ -11,10 +11,6 @@ Object {
         "title": "Endpoint Endpoint name created",
         "variant": "success",
       },
-      "rejected": Object {
-        "title": "Failed to create endpoint Endpoint name",
-        "variant": "danger",
-      },
     },
   },
   "payload": Promise {},
@@ -30,10 +26,6 @@ Object {
         "title": "Endpoint Endpoint name deleted",
         "variant": "success",
       },
-      "rejected": Object {
-        "title": "Failed to delete endpoint Endpoint name",
-        "variant": "danger",
-      },
     },
   },
   "payload": Promise {},
@@ -43,14 +35,6 @@ Object {
 
 exports[`fetchApps returns a state object 1`] = `
 Object {
-  "meta": Object {
-    "notifications": Object {
-      "rejected": Object {
-        "title": "Failed to load apps",
-        "variant": "danger",
-      },
-    },
-  },
   "payload": Promise {},
   "type": "FETCH_APPS",
 }
@@ -58,14 +42,6 @@ Object {
 
 exports[`fetchEndpoint returns a state object 1`] = `
 Object {
-  "meta": Object {
-    "notifications": Object {
-      "rejected": Object {
-        "title": "Failed to load endpoint 1",
-        "variant": "danger",
-      },
-    },
-  },
   "payload": Promise {},
   "type": "FETCH_ENDPOINT",
 }
@@ -75,12 +51,6 @@ exports[`fetchEndpoints returns a state object 1`] = `
 Object {
   "meta": Object {
     "endpoint": "/endpoints?offset=0&limit=10&sort_by=name asc",
-    "notifications": Object {
-      "rejected": Object {
-        "title": "Failed to load endpoints",
-        "variant": "danger",
-      },
-    },
     "partial": false,
     "sortBy": "name asc",
   },
@@ -91,14 +61,6 @@ Object {
 
 exports[`fetchFilter returns a state object 1`] = `
 Object {
-  "meta": Object {
-    "notifications": Object {
-      "rejected": Object {
-        "title": "Failed to load filter",
-        "variant": "danger",
-      },
-    },
-  },
   "payload": Promise {},
   "type": "FETCH_FILTER",
 }
@@ -119,10 +81,6 @@ Object {
         "title": "Test event delivery successful",
         "variant": "success",
       },
-      "rejected": Object {
-        "title": "Test event delivery failed",
-        "variant": "warning",
-      },
     },
   },
   "payload": Promise {},
@@ -132,14 +90,6 @@ Object {
 
 exports[`toggleEndpoint returns a state object 1`] = `
 Object {
-  "meta": Object {
-    "notifications": Object {
-      "rejected": Object {
-        "title": "Failed to toggle endpoint 1",
-        "variant": "danger",
-      },
-    },
-  },
   "payload": Promise {},
   "type": "SUBMIT_ENDPOINT",
 }
@@ -155,10 +105,6 @@ Object {
       "fulfilled": Object {
         "title": "Endpoint Endpoint name updated",
         "variant": "success",
-      },
-      "rejected": Object {
-        "title": "Failed to update endpoint Endpoint name",
-        "variant": "danger",
       },
     },
   },

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -29,28 +29,14 @@ export const fetchEndpoints = (page, perPage, sortBy = 'name asc', partial = fal
         meta: {
             endpoint: url,
             sortBy,
-            partial,
-            notifications: {
-                rejected: {
-                    variant: 'danger',
-                    title: 'Failed to load endpoints'
-                }
-            }
+            partial
         }
     };
 };
 
 export const fetchEndpoint = (id) => ({
     type: FETCH_ENDPOINT,
-    payload: ApiClient.get(`/endpoints/${ id }`),
-    meta: {
-        notifications: {
-            rejected: {
-                variant: 'danger',
-                title: `Failed to load endpoint ${ id }`
-            }
-        }
-    }
+    payload: ApiClient.get(`/endpoints/${ id }`)
 });
 
 export const createEndpoint = (data) => {
@@ -60,10 +46,6 @@ export const createEndpoint = (data) => {
         meta: {
             data,
             notifications: {
-                rejected: {
-                    variant: 'danger',
-                    title: `Failed to create endpoint ${ data.name }`
-                },
                 fulfilled: {
                     variant: 'success',
                     title: `Endpoint ${ data.name } created`
@@ -80,10 +62,6 @@ export const updateEndpoint = (id, data) => {
         meta: {
             data,
             notifications: {
-                rejected: {
-                    variant: 'danger',
-                    title: `Failed to update endpoint ${ data.name }`
-                },
                 fulfilled: {
                     variant: 'success',
                     title: `Endpoint ${ data.name } updated`
@@ -96,15 +74,7 @@ export const updateEndpoint = (id, data) => {
 export const toggleEndpoint = (id, on) => {
     return {
         type: SUBMIT_ENDPOINT,
-        payload: ApiClient.update(`/endpoints/${ id }`, { endpoint: { active: on }}),
-        meta: {
-            notifications: {
-                rejected: {
-                    variant: 'danger',
-                    title: `Failed to toggle endpoint ${ id }`
-                }
-            }
-        }
+        payload: ApiClient.update(`/endpoints/${ id }`, { endpoint: { active: on }})
     };
 };
 
@@ -113,10 +83,6 @@ export const deleteEndpoint = (id, name) => ({
     payload: ApiClient.destroy(`/endpoints/${ id }`).then(() => ({ id })),
     meta: {
         notifications: {
-            rejected: {
-                variant: 'danger',
-                title: `Failed to delete endpoint ${ name }`
-            },
             fulfilled: {
                 variant: 'success',
                 title: `Endpoint ${ name } deleted`
@@ -135,10 +101,6 @@ export const testEndpoint = (endpointId) => ({
     meta: {
         endpointId,
         notifications: {
-            rejected: {
-                variant: 'warning',
-                title: 'Test event delivery failed'
-            },
             fulfilled: {
                 variant: 'success',
                 title: 'Test event delivery successful'
@@ -150,32 +112,9 @@ export const testEndpoint = (endpointId) => ({
 export const fetchFilter = (endpointId) => ({
     type: FETCH_FILTER,
     payload: ApiClient.get(`/endpoints/${ endpointId }/filter`)
-    .catch((error) => {
-        if (error.message === 'Not Found') {
-            return { data: null };
-        } else {
-            throw error;
-        }
-    }),
-    meta: {
-        notifications: {
-            rejected: {
-                variant: 'danger',
-                title: 'Failed to load filter'
-            }
-        }
-    }
 });
 
 export const fetchApps = () => ({
     type: FETCH_APPS,
-    payload: ApiClient.get('/apps'),
-    meta: {
-        notifications: {
-            rejected: {
-                variant: 'danger',
-                title: 'Failed to load apps'
-            }
-        }
-    }
+    payload: ApiClient.get('/apps')
 });

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -111,7 +111,7 @@ export const testEndpoint = (endpointId) => ({
 
 export const fetchFilter = (endpointId) => ({
     type: FETCH_FILTER,
-    payload: ApiClient.get(`/endpoints/${ endpointId }/filter`)
+    payload: ApiClient.get(`/endpoints/${ endpointId }/filter`, { ignore404: true })
 });
 
 export const fetchApps = () => ({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -13,7 +13,10 @@ export function init (...middleware) {
 
     registry = new ReducerRegistry({}, [
         promiseMiddleware(),
-        notificationsMiddleware(),
+        notificationsMiddleware({
+            errorTitleKey: 'title',
+            errorDescriptionKey: 'detail'
+        }),
         ...middleware
     ]);
 

--- a/src/store/reducers/EndpointsReducer.js
+++ b/src/store/reducers/EndpointsReducer.js
@@ -145,7 +145,8 @@ export const endpointsReducer = function(state = initialStateFor('endpoints', {}
                 ...state,
                 submitting: false,
                 endpoint: action.meta.data,
-                error: true
+                error: true,
+                errors: action.payload.errors
             };
 
         case NEW_ENDPOINT:

--- a/src/store/reducers/EndpointsReducer.js
+++ b/src/store/reducers/EndpointsReducer.js
@@ -87,8 +87,8 @@ export const endpointsReducer = function(state = initialStateFor('endpoints', {}
             return {
                 ...state,
                 loading: false,
-                error: action.payload.message,
-                endpoints: {}
+                endpoints: {},
+                error: true
             };
 
         case pendingMessage(FETCH_ENDPOINT):
@@ -110,13 +110,13 @@ export const endpointsReducer = function(state = initialStateFor('endpoints', {}
             return {
                 ...state,
                 loading: false,
-                error: action.payload.message
+                error: true
             };
 
         case failureMessage(DELETE_ENDPOINT):
             return {
                 ...state,
-                error: action.payload.message
+                error: true
             };
 
         case successMessage(DELETE_ENDPOINT):
@@ -145,8 +145,7 @@ export const endpointsReducer = function(state = initialStateFor('endpoints', {}
                 ...state,
                 submitting: false,
                 endpoint: action.meta.data,
-                errors: action.payload,
-                error: action.payload.message
+                error: true
             };
 
         case NEW_ENDPOINT:

--- a/src/store/reducers/EndpointsReducer.test.js
+++ b/src/store/reducers/EndpointsReducer.test.js
@@ -127,7 +127,7 @@ describe('endpoint reducer', () => {
     });
 
     it('should handle FETCH_ENDPOINTS_FAILURE', () => {
-        const error = 'It broke';
+        const error = true;
         const newState = endpointsReducer(
             endpointInitialState,
             fromRequest(failureMessage(FETCH_ENDPOINTS), { message: error })
@@ -140,7 +140,7 @@ describe('endpoint reducer', () => {
     });
 
     it('should handle FETCH_ENDPOINT_FAILURE', () => {
-        const error = 'It broke';
+        const error = true;
         const newState = endpointsReducer(
             endpointInitialState,
             fromRequest(failureMessage(FETCH_ENDPOINT), { message: error })
@@ -183,7 +183,7 @@ describe('endpoint reducer', () => {
     });
 
     it('should handle SUBMIT_ENDPOINT_FAILURE', () => {
-        const error = 'Submit failed!';
+        const error = true;
         const action = fromRequest(failureMessage(SUBMIT_ENDPOINT), { message: error }, { data: {}});
         const newState = endpointsReducer(endpointInitialState, action);
         expect(newState).toEqual({
@@ -191,10 +191,7 @@ describe('endpoint reducer', () => {
             loading: false,
             submitting: false,
             endpoint: {},
-            error,
-            errors: {
-                message: error
-            }
+            error
         });
     });
 
@@ -210,7 +207,7 @@ describe('endpoint reducer', () => {
     });
 
     it('should handle DELETE_ENDPOINT_FAILURE', () => {
-        const error = 'Delete failed!';
+        const error = true;
         const action = fromRequest(failureMessage(DELETE_ENDPOINT), { message: error });
         const newState = endpointsReducer(endpointInitialState, action);
         expect(newState).toEqual({

--- a/src/store/reducers/FilterReducer.js
+++ b/src/store/reducers/FilterReducer.js
@@ -10,8 +10,7 @@ import {
 } from './reducerHelper';
 
 export const normalizeFilterData = (payload) => {
-    return payload.data === null ? {}
-        : normalizeData(payload, 'filter')[payload.data.id];
+    return payload.data !== null && typeof(payload.data) !== 'undefined' ? normalizeData(payload, 'filter')[payload.data.id] : {};
 };
 
 export const filterReducer = function(state = initialStateFor('filter', {}), action) {


### PR DESCRIPTION
This rewrites the API client to reject a promise in case an error occurs and trigger the notifications middleware, which will look for title and details in the response to show the error.

Requires https://github.com/RedHatInsights/notifications-backend/pull/54 in the backend