### PR TITLE
Fix off by one error when fetching endpoint after deletion

### DIFF
--- a/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
+++ b/src/SmartComponents/NotificationsIndex/NotificationsIndex.js
@@ -106,7 +106,7 @@ export class NotificationsIndex extends Component {
     getNextEndpoint = () => {
         const { direction, index } = this.state.sortBy;
         const column = this.state.columns[index].key;
-        return this.props.fetchEndpoints(this.state.perPage * (this.state.page + 1), 1, `${column} ${direction}`, true);
+        return this.props.fetchEndpoints(this.state.perPage * this.state.page, 1, `${column} ${direction}`, true);
     }
 
     onPerPageSelect = (_event, perPage) => {


### PR DESCRIPTION
If you had 12 endpoints, per page set to 10 and was on page 1, deleting an
endpoint would send a request to the server with limit 1 and offset 19 (should
be 9).

fixes RHINOTIF-71